### PR TITLE
Add support for inverters

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ All Victron MPPT Chargers providing a ve.direct port.
 
 ## Tested devices
 
+  * Victron SmartSolar MPPT 75/15
   * Victron SmartSolar MPPT 100/20
   * Victron SmartSolar MPPT 150/35
   * Victron SmartSolar MPPT 250/70
+  * Victron Phoenix Inverter 12/500
 
 ## Requirements
 

--- a/components/victron/README.md
+++ b/components/victron/README.md
@@ -21,7 +21,8 @@ The `uart_id` is optional.
 
 All sensors are optional.
 
-The available numeric sensors are:
+The available numeric sensors are
+for MPPT:
 - `max_power_yesterday`
 - `max_power_today`
 - `yield_total`
@@ -34,13 +35,48 @@ The available numeric sensors are:
 - `day_number`
 - `charger_status`
 - `error_code`
-- `tracker_operation`
+- `tracking_mode_id`
 - `load_current`
 
-The available text sensors are:
-- `charger_text`
-- `error_text`
-- `tracker_text`
-- `fw_version`
-- `pid`
+for inverters:
+- `ac_out_voltage`
+- `ac_out_current`
+- `battery_voltage`
+- `warning_code`
+- `charger_status` (= State of operation)
+- `device_mode_id`
+
+
+The available text sensors are
+for MPPT:
+- `device_type`
+- `charging_mode`
+- `error`
+- `tracking_mode`
+- `firmware_version`
+
+for inverters:
+- `device_type`
+- `device_mode`
+- `warning`
+- `firmware_version`
+
+
+Example for multiple devices:
+```yaml
+victron:
+  - id: victron_mppt
+    uart_id: the_uart_of_mppt
+  - id: victron_inverter
+    uart_id: the_uart_of_inverter
+
+text_sensor:
+  - platform: victron
+    victron_id: victron_mppt
+    device_type:
+      name: "MPPT device type"
+  - platform: victron
+    victron_id: victron_inverter
+    device_type:
+      name: "Inverter device type"
 ```

--- a/components/victron/sensor.py
+++ b/components/victron/sensor.py
@@ -34,11 +34,16 @@ CONF_BATTERY_CURRENT = "battery_current"
 CONF_DAY_NUMBER = "day_number"
 CONF_CHARGING_MODE_ID = "charging_mode_id"
 CONF_ERROR_CODE = "error_code"
+CONF_WARNING_CODE = "warning_code"
 CONF_TRACKING_MODE_ID = "tracking_mode_id"
+CONF_DEVICE_MODE_ID = "device_mode_id"
 CONF_LOAD_CURRENT = "load_current"
+CONF_AC_OUT_VOLTAGE = "ac_out_voltage"
+CONF_AC_OUT_CURRENT = "ac_out_current"
 
 SENSORS = [
     CONF_BATTERY_VOLTAGE,
+    CONF_AC_OUT_VOLTAGE,
     CONF_MAX_POWER_YESTERDAY,
     CONF_MAX_POWER_TODAY,
     CONF_YIELD_TOTAL,
@@ -47,10 +52,13 @@ SENSORS = [
     CONF_PANEL_VOLTAGE,
     CONF_PANEL_POWER,
     CONF_BATTERY_CURRENT,
+    CONF_AC_OUT_CURRENT,
     CONF_DAY_NUMBER,
     CONF_CHARGING_MODE_ID,
     CONF_ERROR_CODE,
+    CONF_WARNING_CODE,
     CONF_TRACKING_MODE_ID,
+    CONF_DEVICE_MODE_ID,
     CONF_LOAD_CURRENT,
 ]
 
@@ -81,7 +89,13 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_BATTERY_VOLTAGE): sensor.sensor_schema(
             UNIT_VOLT, ICON_FLASH, 3, DEVICE_CLASS_VOLTAGE
         ),
+        cv.Optional(CONF_AC_OUT_VOLTAGE): sensor.sensor_schema(
+            UNIT_VOLT, ICON_FLASH, 3, DEVICE_CLASS_VOLTAGE
+        ),
         cv.Optional(CONF_BATTERY_CURRENT): sensor.sensor_schema(
+            UNIT_AMPERE, ICON_CURRENT_AC, 3, DEVICE_CLASS_CURRENT
+        ),
+        cv.Optional(CONF_AC_OUT_CURRENT): sensor.sensor_schema(
             UNIT_AMPERE, ICON_CURRENT_AC, 3, DEVICE_CLASS_CURRENT
         ),
         cv.Optional(CONF_DAY_NUMBER): sensor.sensor_schema(
@@ -93,7 +107,13 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_ERROR_CODE): sensor.sensor_schema(
             UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY
         ),
+        cv.Optional(CONF_WARNING_CODE): sensor.sensor_schema(
+            UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY
+        ),
         cv.Optional(CONF_TRACKING_MODE_ID): sensor.sensor_schema(
+            UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY
+        ),
+        cv.Optional(CONF_DEVICE_MODE_ID): sensor.sensor_schema(
             UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY
         ),
         cv.Optional(CONF_LOAD_CURRENT): sensor.sensor_schema(

--- a/components/victron/text_sensor.py
+++ b/components/victron/text_sensor.py
@@ -10,14 +10,18 @@ CODEOWNERS = ["@KinDR007"]
 
 CONF_CHARGING_MODE = "charging_mode"
 CONF_ERROR = "error"
+CONF_WARNING = "warning"
 CONF_TRACKING_MODE = "tracking_mode"
+CONF_DEVICE_MODE = "device_mode"
 CONF_FIRMWARE_VERSION = "firmware_version"
 CONF_DEVICE_TYPE = "device_type"
 
 TEXT_SENSORS = [
     CONF_CHARGING_MODE,
     CONF_ERROR,
+    CONF_WARNING,
     CONF_TRACKING_MODE,
+    CONF_DEVICE_MODE,
     CONF_FIRMWARE_VERSION,
     CONF_DEVICE_TYPE,
 ]
@@ -31,7 +35,13 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_ERROR): text_sensor.TEXT_SENSOR_SCHEMA.extend(
             {cv.GenerateID(): cv.declare_id(text_sensor.TextSensor)}
         ),
+        cv.Optional(CONF_WARNING): text_sensor.TEXT_SENSOR_SCHEMA.extend(
+            {cv.GenerateID(): cv.declare_id(text_sensor.TextSensor)}
+        ),
         cv.Optional(CONF_TRACKING_MODE): text_sensor.TEXT_SENSOR_SCHEMA.extend(
+            {cv.GenerateID(): cv.declare_id(text_sensor.TextSensor)}
+        ),
+        cv.Optional(CONF_DEVICE_MODE): text_sensor.TEXT_SENSOR_SCHEMA.extend(
             {cv.GenerateID(): cv.declare_id(text_sensor.TextSensor)}
         ),
         cv.Optional(CONF_FIRMWARE_VERSION): text_sensor.TEXT_SENSOR_SCHEMA.extend(

--- a/components/victron/victron.h
+++ b/components/victron/victron.h
@@ -29,22 +29,36 @@ class VictronComponent : public uart::UARTDevice, public Component {
   void set_battery_current_sensor(sensor::Sensor *battery_current_sensor) {
     battery_current_sensor_ = battery_current_sensor;
   }
+  void set_ac_out_voltage_sensor(sensor::Sensor *ac_out_voltage_sensor) {
+    ac_out_voltage_sensor_ = ac_out_voltage_sensor;
+  }
+  void set_ac_out_current_sensor(sensor::Sensor *ac_out_current_sensor) {
+    ac_out_current_sensor_ = ac_out_current_sensor;
+  }
   void set_load_current_sensor(sensor::Sensor *load_current_sensor) { load_current_sensor_ = load_current_sensor; }
   void set_day_number_sensor(sensor::Sensor *day_number_sensor) { day_number_sensor_ = day_number_sensor; }
   void set_charging_mode_id_sensor(sensor::Sensor *charging_mode_id_sensor) {
     charging_mode_id_sensor_ = charging_mode_id_sensor;
   }
   void set_error_code_sensor(sensor::Sensor *error_code_sensor) { error_code_sensor_ = error_code_sensor; }
+  void set_warning_code_sensor(sensor::Sensor *warning_code_sensor) { warning_code_sensor_ = warning_code_sensor; }
   void set_tracking_mode_id_sensor(sensor::Sensor *tracking_mode_id_sensor) {
     tracking_mode_id_sensor_ = tracking_mode_id_sensor;
+  }
+  void set_device_mode_id_sensor(sensor::Sensor *device_mode_id_sensor) {
+    device_mode_id_sensor_ = device_mode_id_sensor;
   }
 
   void set_charging_mode_text_sensor(text_sensor::TextSensor *charging_mode_text_sensor) {
     charging_mode_text_sensor_ = charging_mode_text_sensor;
   }
   void set_error_text_sensor(text_sensor::TextSensor *error_text_sensor) { error_text_sensor_ = error_text_sensor; }
+  void set_warning_text_sensor(text_sensor::TextSensor *warning_text_sensor) { warning_text_sensor_ = warning_text_sensor; }
   void set_tracking_mode_text_sensor(text_sensor::TextSensor *tracking_mode_text_sensor) {
     tracking_mode_text_sensor_ = tracking_mode_text_sensor;
+  }
+  void set_device_mode_text_sensor(text_sensor::TextSensor *device_mode_text_sensor) {
+    device_mode_text_sensor_ = device_mode_text_sensor;
   }
   void set_firmware_version_text_sensor(text_sensor::TextSensor *firmware_version_text_sensor) {
     firmware_version_text_sensor_ = firmware_version_text_sensor;
@@ -70,15 +84,22 @@ class VictronComponent : public uart::UARTDevice, public Component {
   sensor::Sensor *panel_power_sensor_{nullptr};
   sensor::Sensor *battery_voltage_sensor_{nullptr};
   sensor::Sensor *battery_current_sensor_{nullptr};
+  sensor::Sensor *ac_out_voltage_sensor_{nullptr};
+  sensor::Sensor *ac_out_current_sensor_{nullptr};
   sensor::Sensor *load_current_sensor_{nullptr};
   sensor::Sensor *day_number_sensor_{nullptr};
+  sensor::Sensor *device_mode_sensor_{nullptr};
   sensor::Sensor *charging_mode_id_sensor_{nullptr};
   sensor::Sensor *error_code_sensor_{nullptr};
+  sensor::Sensor *warning_code_sensor_{nullptr};
   sensor::Sensor *tracking_mode_id_sensor_{nullptr};
+  sensor::Sensor *device_mode_id_sensor_{nullptr};
 
   text_sensor::TextSensor *charging_mode_text_sensor_{nullptr};
   text_sensor::TextSensor *error_text_sensor_{nullptr};
+  text_sensor::TextSensor *warning_text_sensor_{nullptr};
   text_sensor::TextSensor *tracking_mode_text_sensor_{nullptr};
+  text_sensor::TextSensor *device_mode_text_sensor_{nullptr};
   text_sensor::TextSensor *firmware_version_text_sensor_{nullptr};
   text_sensor::TextSensor *device_type_text_sensor_{nullptr};
 


### PR DESCRIPTION
I have added the fields for the Phoenix inverters and fixed the readme in some aspects.

Open for discussion: "charger_status" (CS field in VE.direct protocol) has a different meaning for inverters. I didn't want to rename it with this pull request, so it will not break existing installations.