### PR TITLE
Update sensor.py - correct units for depth of discharge

### DIFF
--- a/components/victron/sensor.py
+++ b/components/victron/sensor.py
@@ -339,19 +339,19 @@ CONFIG_SCHEMA = cv.Schema(
             device_class=DEVICE_CLASS_EMPTY,
         ),
         cv.Optional(CONF_DEPTH_OF_THE_DEEPEST_DISCHARGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE,
+            unit_of_measurement=UNIT_AMPERE_HOURS,
             icon=ICON_CURRENT_AC,
             accuracy_decimals=3,
             device_class=DEVICE_CLASS_CURRENT,
         ),
         cv.Optional(CONF_DEPTH_OF_THE_LAST_DISCHARGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE,
+            unit_of_measurement=UNIT_AMPERE_HOURS,
             icon=ICON_CURRENT_AC,
             accuracy_decimals=3,
             device_class=DEVICE_CLASS_CURRENT,
         ),
         cv.Optional(CONF_DEPTH_OF_THE_AVERAGE_DISCHARGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE,
+            unit_of_measurement=UNIT_AMPERE_HOURS,
             icon=ICON_CURRENT_AC,
             accuracy_decimals=3,
             device_class=DEVICE_CLASS_CURRENT,


### PR DESCRIPTION
Hi,
I recognized that the sensors for the depth of discharge are in 'A' and not in 'Ah.'
![deppest_discharge_units](https://user-images.githubusercontent.com/44926214/200837069-be6a89d4-552c-4c6c-bc76-50041206ddc9.JPG)

'Ah' would be also in line with the units in the official victron app.
![deppest_discharge_units_Ah](https://user-images.githubusercontent.com/44926214/200837527-34115f81-b010-4450-ab18-0d26bc66c80f.JPG)


![image](https://user-images.githubusercontent.com/44926214/200838419-d5be1aa7-8971-4940-856f-a8fc469a9521.jpeg)


This is the first time I'm doing this, so please be patient. 