### PR TITLE
MPPT 150/100 support update for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ All Victron devices providing a ve.direct port.
   * Victron SmartSolar MPPT 75/15
   * Victron SmartSolar MPPT 100/20
   * Victron SmartSolar MPPT 150/35
+  * Victron SmartSolar MPPT VE.Can 150/100 rev2 (Using VE.Direct port)
   * Victron SmartSolar MPPT 250/70
   * Victron Phoenix Inverter 12/500
 


### PR DESCRIPTION
Update to include tested Victron SmartSolar MPPT VE.Can 150/100 rev2.  Also added a node that this was not using the CAN functionality.