### PR TITLE
stop blocking ESPHome

### DIFF
--- a/components/victron/victron.h
+++ b/components/victron/victron.h
@@ -287,6 +287,7 @@ class VictronComponent : public uart::UARTDevice, public Component {
   int state_{0};
   std::string label_;
   std::string value_;
+  uint32_t begin_frame_{0};
   uint32_t last_transmission_{0};
   uint32_t last_publish_{0};
   uint32_t throttle_{0};


### PR DESCRIPTION
Updated to rely on the ESPHome event loop instead of waiting to read the entire serial buffer at a time.

It seems to work in the sense that it no longer throws warnings about blocking esphome too long, however now it randomly throws errors like: `[D][victron:1024]: Unhandled property: HS 0`. which seems like something is getting corrupted, which wasn't before. Maybe increasing the uart buffer would help.

fixes #132 