### PR TITLE
Add ESPHome 2024.6.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ All Victron devices providing a ve.direct port.
 
 ## Requirements
 
-* [ESPHome 2021.10 or higher](https://github.com/esphome/esphome/releases).
+* [ESPHome 2026.6.0 or higher](https://github.com/esphome/esphome/releases).
 * Generic ESP32 or ESP8266 board
 
 ## Schematics

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ All Victron devices providing a ve.direct port.
 
 ## Requirements
 
-* [ESPHome 2026.6.0 or higher](https://github.com/esphome/esphome/releases).
+* [ESPHome 2024.6.0 or higher](https://github.com/esphome/esphome/releases).
 * Generic ESP32 or ESP8266 board
 
 ## Schematics

--- a/bluesmart-charger-esp32-example.yaml
+++ b/bluesmart-charger-esp32-example.yaml
@@ -1,6 +1,5 @@
 substitutions:
   name: bluesmart-charger
-  config_version: "v2021.06.21"
   external_components_source: github://KinDR007/VictronMPPT-ESPHOME@main
 
 esphome:

--- a/bluesmart-charger-esp32-example.yaml
+++ b/bluesmart-charger-esp32-example.yaml
@@ -4,10 +4,10 @@ substitutions:
 
 esphome:
   name: ${name}
+  min_version: 2024.6.0
 
 esp32:
   board: esp32dev
-  min_version: 2024.6.0
 
 external_components:
   - source: ${external_components_source}

--- a/bluesmart-charger-esp32-example.yaml
+++ b/bluesmart-charger-esp32-example.yaml
@@ -7,6 +7,7 @@ esphome:
 
 esp32:
   board: esp32dev
+  min_version: 2024.6.0
 
 external_components:
   - source: ${external_components_source}
@@ -17,7 +18,8 @@ wifi:
   password: !secret wifi_password
 
 ota:
-# api:
+  - platform: esphome
+#    api:
 
 logger:
   baud_rate: 0

--- a/bluesmart-charger-esp32-example.yaml
+++ b/bluesmart-charger-esp32-example.yaml
@@ -1,5 +1,6 @@
 substitutions:
   name: bluesmart-charger
+  config_version: "v2021.06.21"
   external_components_source: github://KinDR007/VictronMPPT-ESPHOME@main
 
 esphome:

--- a/bluesmart-charger-esp32-example.yaml
+++ b/bluesmart-charger-esp32-example.yaml
@@ -19,7 +19,6 @@ wifi:
 
 ota:
   - platform: esphome
-#    api:
 
 logger:
   baud_rate: 0

--- a/bluesmart-charger-esp32-example.yaml
+++ b/bluesmart-charger-esp32-example.yaml
@@ -18,7 +18,7 @@ wifi:
   password: !secret wifi_password
 
 ota:
-  - platform: esphome
+  platform: esphome
 
 logger:
   baud_rate: 0

--- a/bluesmart-charger-esp8266-example.yaml
+++ b/bluesmart-charger-esp8266-example.yaml
@@ -6,6 +6,7 @@ esphome:
   name: ${name}
   platform: ESP8266
   board: d1_mini
+  min_version: 2024.6.0
 
 external_components:
   - source: ${external_components_source}
@@ -16,7 +17,8 @@ wifi:
   password: !secret wifi_password
 
 ota:
-# api:
+  - platform: esphome
+#    api:
 
 logger:
 

--- a/bluesmart-charger-esp8266-example.yaml
+++ b/bluesmart-charger-esp8266-example.yaml
@@ -18,7 +18,6 @@ wifi:
 
 ota:
   - platform: esphome
-#    api:
 
 logger:
 

--- a/bluesmart-charger-esp8266-example.yaml
+++ b/bluesmart-charger-esp8266-example.yaml
@@ -17,7 +17,7 @@ wifi:
   password: !secret wifi_password
 
 ota:
-  - platform: esphome
+  platform: esphome
 
 logger:
 

--- a/debug-esp32-example.yaml
+++ b/debug-esp32-example.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  min_version: 2024.6.0
 
 esp32:
   board: wemos_d1_mini32
@@ -21,7 +22,10 @@ wifi:
   password: !secret wifi_password
 
 ota:
+  - platform: esphome
+
 api:
+
 logger:
 
 uart:

--- a/debug-esp32-example.yaml
+++ b/debug-esp32-example.yaml
@@ -22,7 +22,7 @@ wifi:
   password: !secret wifi_password
 
 ota:
-  - platform: esphome
+  platform: esphome
 
 api:
 

--- a/debug-esp8266-example.yaml
+++ b/debug-esp8266-example.yaml
@@ -19,7 +19,7 @@ wifi:
   password: !secret wifi_password
 
 ota:
-  - platform: esphome
+  platform: esphome
 
 api:
 

--- a/debug-esp8266-example.yaml
+++ b/debug-esp8266-example.yaml
@@ -8,6 +8,7 @@ esphome:
   name: ${name}
   platform: ESP8266
   board: d1_mini
+  min_version: 2024.6.0
 
 external_components:
   - source: ${external_components_source}
@@ -18,6 +19,8 @@ wifi:
   password: !secret wifi_password
 
 ota:
+  - platform: esphome
+
 api:
 
 logger:

--- a/multi-rs-esp8266-example.yaml
+++ b/multi-rs-esp8266-example.yaml
@@ -6,6 +6,7 @@ esphome:
   name: ${name}
   platform: ESP8266
   board: d1_mini
+  min_version: 2024.6.0
 
 external_components:
   - source: ${external_components_source}
@@ -16,6 +17,7 @@ wifi:
   password: !secret wifi_password
 
 ota:
+  - platform: esphome
 # api:
 
 logger:

--- a/multi-rs-esp8266-example.yaml
+++ b/multi-rs-esp8266-example.yaml
@@ -18,7 +18,6 @@ wifi:
 
 ota:
   - platform: esphome
-# api:
 
 logger:
   baud_rate: 0

--- a/multi-rs-esp8266-example.yaml
+++ b/multi-rs-esp8266-example.yaml
@@ -17,7 +17,7 @@ wifi:
   password: !secret wifi_password
 
 ota:
-  - platform: esphome
+  platform: esphome
 
 logger:
   baud_rate: 0

--- a/phoenix-charger-esp8266-example.yaml
+++ b/phoenix-charger-esp8266-example.yaml
@@ -18,7 +18,6 @@ wifi:
 
 ota:
   - platform: esphome
-# api:
 
 logger:
   baud_rate: 0

--- a/phoenix-charger-esp8266-example.yaml
+++ b/phoenix-charger-esp8266-example.yaml
@@ -17,7 +17,7 @@ wifi:
   password: !secret wifi_password
 
 ota:
-  - platform: esphome
+  platform: esphome
 
 logger:
   baud_rate: 0

--- a/phoenix-charger-esp8266-example.yaml
+++ b/phoenix-charger-esp8266-example.yaml
@@ -6,7 +6,7 @@ esphome:
   name: ${name}
   platform: ESP8266
   board: d1_mini
-  min_version: 2024.6.0  
+  min_version: 2024.6.0
 
 external_components:
   - source: ${external_components_source}

--- a/phoenix-charger-esp8266-example.yaml
+++ b/phoenix-charger-esp8266-example.yaml
@@ -6,6 +6,7 @@ esphome:
   name: ${name}
   platform: ESP8266
   board: d1_mini
+  min_version: 2024.6.0  
 
 external_components:
   - source: ${external_components_source}
@@ -16,6 +17,7 @@ wifi:
   password: !secret wifi_password
 
 ota:
+  - platform: esphome
 # api:
 
 logger:

--- a/phoenix-inverter-esp8266-example.yaml
+++ b/phoenix-inverter-esp8266-example.yaml
@@ -6,6 +6,7 @@ esphome:
   name: ${name}
   platform: ESP8266
   board: d1_mini
+  min_version: 2024.6.0
 
 external_components:
   - source: ${external_components_source}
@@ -16,6 +17,7 @@ wifi:
   password: !secret wifi_password
 
 ota:
+  - platform: esphome
 # api:
 
 logger:

--- a/phoenix-inverter-esp8266-example.yaml
+++ b/phoenix-inverter-esp8266-example.yaml
@@ -18,7 +18,6 @@ wifi:
 
 ota:
   - platform: esphome
-# api:
 
 logger:
   baud_rate: 0

--- a/phoenix-inverter-esp8266-example.yaml
+++ b/phoenix-inverter-esp8266-example.yaml
@@ -17,7 +17,7 @@ wifi:
   password: !secret wifi_password
 
 ota:
-  - platform: esphome
+  platform: esphome
 
 logger:
   baud_rate: 0

--- a/smartshunt-esp8266-example.yaml
+++ b/smartshunt-esp8266-example.yaml
@@ -6,6 +6,7 @@ esphome:
   name: ${name}
   platform: ESP8266
   board: d1_mini
+  min_version: 2024.6.0
 
 external_components:
   - source: ${external_components_source}
@@ -16,6 +17,7 @@ wifi:
   password: !secret wifi_password
 
 ota:
+  - platform: esphome
 # api:
 
 logger:

--- a/smartshunt-esp8266-example.yaml
+++ b/smartshunt-esp8266-example.yaml
@@ -18,7 +18,6 @@ wifi:
 
 ota:
   - platform: esphome
-#    api:
 
 logger:
   baud_rate: 0

--- a/smartshunt-esp8266-example.yaml
+++ b/smartshunt-esp8266-example.yaml
@@ -17,7 +17,7 @@ wifi:
   password: !secret wifi_password
 
 ota:
-  - platform: esphome
+  platform: esphome
 
 logger:
   baud_rate: 0

--- a/smartshunt-esp8266-example.yaml
+++ b/smartshunt-esp8266-example.yaml
@@ -18,7 +18,7 @@ wifi:
 
 ota:
   - platform: esphome
-# api:
+#    api:
 
 logger:
   baud_rate: 0

--- a/smartsolar-mppt-esp8266-example-advanced.yaml
+++ b/smartsolar-mppt-esp8266-example-advanced.yaml
@@ -29,6 +29,7 @@ wifi:
     password: !secret wifi_password
 
 captive_portal:
+
 logger:
   baud_rate: 0
   # level: VERY_VERBOSE

--- a/smartsolar-mppt-esp8266-example-advanced.yaml
+++ b/smartsolar-mppt-esp8266-example-advanced.yaml
@@ -2,7 +2,7 @@ substitutions:
   external_components_source: github://KinDR007/VictronMPPT-ESPHOME@main
   lower_devicename: "victron"
   devicename: "SmartSolar_150_35"
-  config_version: "v2021.05.30"
+  config_version: "v2021.06.21"
   wifi_fast_connect: "false"
   accuracy: "2"
 

--- a/smartsolar-mppt-esp8266-example-advanced.yaml
+++ b/smartsolar-mppt-esp8266-example-advanced.yaml
@@ -11,6 +11,7 @@ esphome:
   platform: ESP8266
   board: d1_mini
   # board: nodemcuv2
+  min_version: 2024.6.0
 
 external_components:
   - source: ${external_components_source}
@@ -35,11 +36,10 @@ logger:
 
 # Enable Home Assistant API
 api:
-  password: "pass"
   reboot_timeout: 0s
 
 ota:
-  password: "pass"
+  - platform: esphome
 
 web_server:
   port: 80

--- a/smartsolar-mppt-esp8266-example-advanced.yaml
+++ b/smartsolar-mppt-esp8266-example-advanced.yaml
@@ -40,7 +40,7 @@ api:
   reboot_timeout: 0s
 
 ota:
-  - platform: esphome
+  platform: esphome
 
 web_server:
   port: 80

--- a/smartsolar-mppt-esp8266-example-advanced.yaml
+++ b/smartsolar-mppt-esp8266-example-advanced.yaml
@@ -2,7 +2,7 @@ substitutions:
   external_components_source: github://KinDR007/VictronMPPT-ESPHOME@main
   lower_devicename: "victron"
   devicename: "SmartSolar_150_35"
-  config_version: "v2021.06.21"
+  config_version: "v2024.06.21"
   wifi_fast_connect: "false"
   accuracy: "2"
 

--- a/smartsolar-mppt-esp8266-example-multiple-uarts.yaml
+++ b/smartsolar-mppt-esp8266-example-multiple-uarts.yaml
@@ -19,7 +19,7 @@ wifi:
   password: !secret wifi_password
 
 ota:
-  - platform: esphome
+  platform: esphome
 
 logger:
   baud_rate: 0

--- a/smartsolar-mppt-esp8266-example-multiple-uarts.yaml
+++ b/smartsolar-mppt-esp8266-example-multiple-uarts.yaml
@@ -20,7 +20,6 @@ wifi:
 
 ota:
   - platform: esphome
-#    api:
 
 logger:
   baud_rate: 0

--- a/smartsolar-mppt-esp8266-example-multiple-uarts.yaml
+++ b/smartsolar-mppt-esp8266-example-multiple-uarts.yaml
@@ -8,6 +8,7 @@ esphome:
   name: ${name}
   platform: ESP8266
   board: d1_mini
+  min_version: 2024.6.0
 
 external_components:
   - source: ${external_components_source}
@@ -18,7 +19,8 @@ wifi:
   password: !secret wifi_password
 
 ota:
-# api:
+  - platform: esphome
+#    api:
 
 logger:
   baud_rate: 0

--- a/smartsolar-mppt-esp8266-example.yaml
+++ b/smartsolar-mppt-esp8266-example.yaml
@@ -18,7 +18,6 @@ wifi:
 
 ota:
   - platform: esphome
-#    api:
 
 logger:
   baud_rate: 0

--- a/smartsolar-mppt-esp8266-example.yaml
+++ b/smartsolar-mppt-esp8266-example.yaml
@@ -6,6 +6,7 @@ esphome:
   name: ${name}
   platform: ESP8266
   board: d1_mini
+  min_version: 2024.6.0
 
 external_components:
   - source: ${external_components_source}
@@ -16,7 +17,8 @@ wifi:
   password: !secret wifi_password
 
 ota:
-# api:
+  - platform: esphome
+#    api:
 
 logger:
   baud_rate: 0

--- a/smartsolar-mppt-esp8266-example.yaml
+++ b/smartsolar-mppt-esp8266-example.yaml
@@ -17,7 +17,7 @@ wifi:
   password: !secret wifi_password
 
 ota:
-  - platform: esphome
+  platform: esphome
 
 logger:
   baud_rate: 0

--- a/tests/emulator-all-keys.yaml
+++ b/tests/emulator-all-keys.yaml
@@ -13,7 +13,10 @@ wifi:
   password: !secret wifi_password
 
 api:
+
 ota:
+  platform: esphome
+
 logger:
   level: DEBUG
 

--- a/tests/fake-bluesmart-ip22-0xa332.yaml
+++ b/tests/fake-bluesmart-ip22-0xa332.yaml
@@ -13,7 +13,10 @@ wifi:
   password: !secret wifi_password
 
 api:
+
 ota:
+  platform: esphome
+
 logger:
   level: DEBUG
 

--- a/tests/fake-bluesmart-ip65-0xa30a.yaml
+++ b/tests/fake-bluesmart-ip65-0xa30a.yaml
@@ -13,7 +13,10 @@ wifi:
   password: !secret wifi_password
 
 api:
+
 ota:
+  platform: esphome
+
 logger:
   level: DEBUG
 

--- a/tests/fake-bmv600.yaml
+++ b/tests/fake-bmv600.yaml
@@ -13,7 +13,10 @@ wifi:
   password: !secret wifi_password
 
 api:
+
 ota:
+  platform: esphome
+
 logger:
   level: DEBUG
 

--- a/tests/fake-bmv700.yaml
+++ b/tests/fake-bmv700.yaml
@@ -13,7 +13,10 @@ wifi:
   password: !secret wifi_password
 
 api:
+
 ota:
+  platform: esphome
+
 logger:
   level: DEBUG
 

--- a/tests/fake-bmv710.yaml
+++ b/tests/fake-bmv710.yaml
@@ -13,7 +13,10 @@ wifi:
   password: !secret wifi_password
 
 api:
+
 ota:
+  platform: esphome
+
 logger:
   level: DEBUG
 

--- a/tests/fake-bmv712.yaml
+++ b/tests/fake-bmv712.yaml
@@ -13,7 +13,10 @@ wifi:
   password: !secret wifi_password
 
 api:
+
 ota:
+  platform: esphome
+
 logger:
   level: DEBUG
 

--- a/tests/fake-multi-rs-solar.yaml
+++ b/tests/fake-multi-rs-solar.yaml
@@ -13,7 +13,10 @@ wifi:
   password: !secret wifi_password
 
 api:
+
 ota:
+  platform: esphome
+
 logger:
   level: DEBUG
 

--- a/tests/fake-phoenix-inverter.yaml
+++ b/tests/fake-phoenix-inverter.yaml
@@ -13,7 +13,10 @@ wifi:
   password: !secret wifi_password
 
 api:
+
 ota:
+  platform: esphome
+
 logger:
   level: DEBUG
 

--- a/tests/fake-smartsolar-mppt.yaml
+++ b/tests/fake-smartsolar-mppt.yaml
@@ -13,7 +13,10 @@ wifi:
   password: !secret wifi_password
 
 api:
+
 ota:
+  platform: esphome
+
 logger:
   level: DEBUG
 


### PR DESCRIPTION
- Added ota "platform" to all (required from ESPHome 2024.6.0)
- Added ESPHome "min_version" to all and adjusted existing to "2024.6.0" 
- Updated minimum version required to '2024.6.0 or greater' in the README.md