### PR TITLE
add new/additional pid for smartsolar mppt 75/15

### DIFF
--- a/components/victron/victron.cpp
+++ b/components/victron/victron.cpp
@@ -388,6 +388,8 @@ static std::string device_type_text(int value) {
       return "SmartSolar MPPT 150|85";
     case 0xA053:
       return "SmartSolar MPPT 75|15";
+    case 0xA075:
+      return "SmartSolar MPPT 75|15 rev2";
     case 0xA054:
       return "SmartSolar MPPT 75|10";
     case 0xA055:


### PR DESCRIPTION
My SmartSolar 75|15 is shown as `unknown` and reports `[10:01:01][D][uart_debug:158]: <<< "PID\t0xA075\r\n"` as _PID_.

Added new PID to `victron.cpp`, but unsure about naming (`rev2`), as type label on device has no rev2 label (but _retail_, don't know if that's normal). Open for different return string.

![image](https://github.com/user-attachments/assets/2436469b-fd74-4259-bad8-81b5ebdec3e0)

![image](https://github.com/user-attachments/assets/9099ecb6-3362-401c-b3e2-d288377a1c40)