### PR TITLE
Add new PID 0xA074 as SmartSolar MPPT 75/10 rev2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ All Victron devices providing a ve.direct port.
 
 ## Tested devices
 
+  * Victron SmartSolar MPPT 75/10 rev2 (0xA074)
   * Victron SmartSolar MPPT 75/15
   * Victron SmartSolar MPPT 100/15
   * Victron SmartSolar MPPT 100/20

--- a/components/victron/victron.cpp
+++ b/components/victron/victron.cpp
@@ -392,6 +392,8 @@ static std::string device_type_text(int value) {
       return "SmartSolar MPPT 75|15 rev2";
     case 0xA054:
       return "SmartSolar MPPT 75|10";
+    case 0xA074:
+      return "SmartSolar MPPT 75|10 rev2";
     case 0xA055:
       return "SmartSolar MPPT 100|15";
     case 0xA056:


### PR DESCRIPTION
I have a SmartSolar MPPT 75/10 connected to a DIY ESPHome board and the "Device Type" is showing as "Unknown"

I have checked the debug logs and the PID for this model is 0xA074.
[17:43:41][D][uart_debug:158]: <<< "PID\t0xA074\r\n"

This must be a new revision, so can it be added to the device list please.