### PR TITLE
Use ESP-IDF

### DIFF
--- a/bluesmart-charger-esp32-example.yaml
+++ b/bluesmart-charger-esp32-example.yaml
@@ -8,6 +8,8 @@ esphome:
 
 esp32:
   board: esp32dev
+  framework:
+    type: esp-idf
 
 external_components:
   - source: ${external_components_source}


### PR DESCRIPTION
Fixes:

```
WARNING 💡 IMPORTANT: This device doesn't have a framework specified!

Currently, ESP32 defaults to the Arduino framework.
This will change to ESP-IDF in ESPHome 2026.1.0.

Note: Newer ESP32 variants (C6, H2, P4, etc.) already use ESP-IDF by default.

Why change? ESP-IDF offers:
  ✨ Up to 40% smaller binaries
  🚀 Better performance and optimization
  📦 Custom-built firmware for your exact needs
  🔧 Active development and testing by ESPHome developers

Trade-offs:
  ⏱️  Compile times are ~25% longer
  🔄 Some components need migration

What should I do?
  Option 1: Migrate to ESP-IDF (recommended)
    Add this to your YAML under 'esp32:':
      framework:
        type: esp-idf

  Option 2: Keep using Arduino (still supported)
    Add this to your YAML under 'esp32:':
      framework:
        type: arduino
```