### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/components/victron/victron.cpp
+++ b/components/victron/victron.cpp
@@ -3,8 +3,7 @@
 #include <algorithm>  // std::min
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace victron {
+namespace esphome::victron {
 
 static const char *const TAG = "victron";
 
@@ -1151,5 +1150,4 @@ void VictronComponent::publish_state_once_(text_sensor::TextSensor *text_sensor,
   text_sensor->publish_state(state);
 }
 
-}  // namespace victron
-}  // namespace esphome
+}  // namespace esphome::victron

--- a/components/victron/victron.h
+++ b/components/victron/victron.h
@@ -6,8 +6,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace victron {
+namespace esphome::victron {
 
 class VictronComponent : public uart::UARTDevice, public Component {
  public:
@@ -308,5 +307,4 @@ class VictronComponent : public uart::UARTDevice, public Component {
   uint32_t throttle_{0};
 };
 
-}  // namespace victron
-}  // namespace esphome
+}  // namespace esphome::victron


### PR DESCRIPTION
Replace the nested namespace declarations with the C++17 concatenated syntax in `victron.h` and `victron.cpp`.

```cpp
// before
namespace esphome {
namespace victron {
...
}  // namespace victron
}  // namespace esphome

// after
namespace esphome::victron {
...
}  // namespace esphome::victron
```