### PR TITLE
Optimize clang-tidy by removing splits, adding incremental scans and fixing platformio cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -309,6 +309,8 @@ jobs:
     needs:
       - bundle
       - common
+    env:
+      GH_TOKEN: ${{ github.token }}
     defaults:
       run:
         working-directory: esphome
@@ -322,20 +324,8 @@ jobs:
             options: --environment esp8266-arduino-tidy --grep USE_ESP8266
             pio_cache_key: tidyesp8266
           - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 Arduino 1/4
-            options: --environment esp32-arduino-tidy --split-num 4 --split-at 1
-            pio_cache_key: tidyesp32
-          - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 Arduino 2/4
-            options: --environment esp32-arduino-tidy --split-num 4 --split-at 2
-            pio_cache_key: tidyesp32
-          - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 Arduino 3/4
-            options: --environment esp32-arduino-tidy --split-num 4 --split-at 3
-            pio_cache_key: tidyesp32
-          - id: clang-tidy
-            name: Run script/clang-tidy for ESP32 Arduino 4/4
-            options: --environment esp32-arduino-tidy --split-num 4 --split-at 4
+            name: Run script/clang-tidy for ESP32 Arduino
+            options: --environment esp32-arduino-tidy
             pio_cache_key: tidyesp32
           - id: clang-tidy
             name: Run script/clang-tidy for ESP32 IDF
@@ -358,18 +348,20 @@ jobs:
           cache-key: ${{ needs.common.outputs.cache-key }}
 
       - name: Cache platformio
-        if: github.ref == 'refs/heads/dev'
+        if: github.ref == 'refs/heads/main'
         uses: actions/cache@v4.2.3
         with:
           path: ~/.platformio
-          key: platformio-${{ matrix.pio_cache_key }}
+          key: platformio-${{ matrix.pio_cache_key }}-${{ hashFiles('esphome/platformio.ini') }}
+          restore-keys: platformio-${{ matrix.pio_cache_key }}-
 
       - name: Cache platformio
-        if: github.ref != 'refs/heads/dev'
+        if: github.ref != 'refs/heads/main'
         uses: actions/cache/restore@v4.2.3
         with:
           path: ~/.platformio
-          key: platformio-${{ matrix.pio_cache_key }}
+          key: platformio-${{ matrix.pio_cache_key }}-${{ hashFiles('esphome/platformio.ini') }}
+          restore-keys: platformio-${{ matrix.pio_cache_key }}-
 
       - name: Register problem matchers
         run: |
@@ -391,7 +383,7 @@ jobs:
       - name: Run clang-tidy
         run: |
           . venv/bin/activate
-          script/clang-tidy --all-headers --fix ${{ matrix.options }} ../components
+          script/clang-tidy --all-headers --fix ${{ matrix.options }} $(ls ../components/)
         env:
           # Also cache libdeps, store them in a ~/.platformio subfolder
           PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
@@ -458,6 +450,22 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache-key: ${{ needs.common.outputs.cache-key }}
 
+      - name: Cache platformio
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache@v4.2.3
+        with:
+          path: ~/.platformio
+          key: platformio-compile-${{ hashFiles('esphome/platformio.ini') }}
+          restore-keys: platformio-compile-
+
+      - name: Cache platformio
+        if: github.ref != 'refs/heads/main'
+        uses: actions/cache/restore@v4.2.3
+        with:
+          path: ~/.platformio
+          key: platformio-compile-${{ hashFiles('esphome/platformio.ini') }}
+          restore-keys: platformio-compile-
+
       - name: Write secrets.yaml
         shell: bash
         run: 'echo -e "wifi_ssid: ssid\nwifi_password: password\nmqtt_host: host\nmqtt_username: username\nmqtt_password: password" > secrets.yaml'
@@ -465,24 +473,40 @@ jobs:
           . venv/bin/activate
           esphome -s external_components_source components compile bluesmart-charger-esp32-example.yaml
           # esphome -s external_components_source components config bluesmart-charger-esp8266-example.yaml
+        env:
+          PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
       - run: |
           . venv/bin/activate
           esphome -s external_components_source components compile smartsolar-mppt-esp8266-example.yaml
+        env:
+          PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
       - run: |
           . venv/bin/activate
           esphome -s external_components_source components compile smartsolar-mppt-esp8266-example-multiple-uarts.yaml
+        env:
+          PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
       - run: |
           . venv/bin/activate
           esphome -s external_components_source components compile smartsolar-mppt-esp8266-example-advanced.yaml
+        env:
+          PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
       - run: |
           . venv/bin/activate
           esphome -s external_components_source components compile smartshunt-esp8266-example.yaml
+        env:
+          PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
       - run: |
           . venv/bin/activate
           esphome -s external_components_source components compile phoenix-charger-esp8266-example.yaml
+        env:
+          PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
       - run: |
           . venv/bin/activate
           esphome -s external_components_source components compile phoenix-inverter-esp8266-example.yaml
+        env:
+          PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps
       - run: |
           . venv/bin/activate
           esphome -s external_components_source components compile debug-esp32-example.yaml
+        env:
+          PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -309,8 +309,6 @@ jobs:
     needs:
       - bundle
       - common
-    env:
-      GH_TOKEN: ${{ github.token }}
     defaults:
       run:
         working-directory: esphome


### PR DESCRIPTION
## Summary

- Remove the 4-way ESP32 Arduino split — with a single external component, splitting wastes CI time without benefit
- Add `GH_TOKEN` to the clang-tidy job environment (required for incremental scan support)
- Fix platformio cache condition: `refs/heads/dev` → `refs/heads/main`
- Add `hashFiles('esphome/platformio.ini')` to cache keys and `restore-keys` for incremental cache restoration
- Switch clang-tidy target from `../components` to `$(ls ../components/)` to enable per-component incremental scanning
- Add platformio cache steps to the `esphome-compile` job
- Add `PLATFORMIO_LIBDEPS_DIR: ~/.platformio/libdeps` to all compile steps so libdeps are stored inside the cached platformio directory