### PR TITLE
CI: Add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
   schedule:
     - cron: 0 12 * * *
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Allows triggering the CI workflow manually from the GitHub Actions UI without requiring a push or pull request.