### PR TITLE
Explicitly initialize pointer members to nullptr

### DIFF
--- a/components/victron/victron.h
+++ b/components/victron/victron.h
@@ -223,8 +223,8 @@ class VictronComponent : public uart::UARTDevice, public Component {
   void publish_state_(text_sensor::TextSensor *text_sensor, const std::string &state);
   void publish_state_once_(text_sensor::TextSensor *text_sensor, const std::string &state);
 
-  binary_sensor::BinarySensor *load_state_binary_sensor_;
-  binary_sensor::BinarySensor *relay_state_binary_sensor_;
+  binary_sensor::BinarySensor *load_state_binary_sensor_{nullptr};
+  binary_sensor::BinarySensor *relay_state_binary_sensor_{nullptr};
 
   sensor::Sensor *max_power_yesterday_sensor_{nullptr};
   sensor::Sensor *max_power_today_sensor_{nullptr};


### PR DESCRIPTION
## Summary

- Add `{nullptr}` initializer to `load_state_binary_sensor_` and `relay_state_binary_sensor_` in `victron.h`

All other `sensor::Sensor *` and `text_sensor::TextSensor *` members already carry `{nullptr}`. These two `binary_sensor::BinarySensor *` members were the only ones missing it, leaving them with an indeterminate value if any code path reads them before they are set.

## Test plan

- [ ] Verify the component compiles without warnings