### PR TITLE
Add min_auth_mode: WPA2 to all wifi configurations

### DIFF
--- a/bluesmart-charger-esp32-example.yaml
+++ b/bluesmart-charger-esp32-example.yaml
@@ -18,6 +18,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/bluesmart-charger-esp8266-example.yaml
+++ b/bluesmart-charger-esp8266-example.yaml
@@ -16,6 +16,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/debug-esp32-example.yaml
+++ b/debug-esp32-example.yaml
@@ -20,6 +20,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/debug-esp8266-example.yaml
+++ b/debug-esp8266-example.yaml
@@ -18,6 +18,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/multi-rs-esp8266-example.yaml
+++ b/multi-rs-esp8266-example.yaml
@@ -16,6 +16,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/phoenix-charger-esp8266-example.yaml
+++ b/phoenix-charger-esp8266-example.yaml
@@ -16,6 +16,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/phoenix-inverter-esp8266-example.yaml
+++ b/phoenix-inverter-esp8266-example.yaml
@@ -16,6 +16,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/smartshunt-esp8266-example.yaml
+++ b/smartshunt-esp8266-example.yaml
@@ -16,6 +16,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/smartsolar-mppt-esp8266-example-advanced.yaml
+++ b/smartsolar-mppt-esp8266-example-advanced.yaml
@@ -20,6 +20,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
   power_save_mode: none
   fast_connect: $wifi_fast_connect
 

--- a/smartsolar-mppt-esp8266-example-multiple-uarts.yaml
+++ b/smartsolar-mppt-esp8266-example-multiple-uarts.yaml
@@ -18,6 +18,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/smartsolar-mppt-esp8266-example.yaml
+++ b/smartsolar-mppt-esp8266-example.yaml
@@ -16,6 +16,7 @@ external_components:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/emulator-all-keys.yaml
+++ b/tests/emulator-all-keys.yaml
@@ -12,6 +12,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/fake-bluesmart-ip22-0xa332.yaml
+++ b/tests/fake-bluesmart-ip22-0xa332.yaml
@@ -12,6 +12,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/fake-bluesmart-ip65-0xa30a.yaml
+++ b/tests/fake-bluesmart-ip65-0xa30a.yaml
@@ -12,6 +12,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/fake-bmv600.yaml
+++ b/tests/fake-bmv600.yaml
@@ -12,6 +12,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/fake-bmv700.yaml
+++ b/tests/fake-bmv700.yaml
@@ -12,6 +12,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/fake-bmv710.yaml
+++ b/tests/fake-bmv710.yaml
@@ -12,6 +12,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/fake-bmv712.yaml
+++ b/tests/fake-bmv712.yaml
@@ -12,6 +12,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/fake-multi-rs-solar.yaml
+++ b/tests/fake-multi-rs-solar.yaml
@@ -12,6 +12,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/fake-phoenix-inverter.yaml
+++ b/tests/fake-phoenix-inverter.yaml
@@ -12,6 +12,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/fake-smartsolar-mppt-150-70-rev3.yaml
+++ b/tests/fake-smartsolar-mppt-150-70-rev3.yaml
@@ -12,6 +12,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome

--- a/tests/fake-smartsolar-mppt.yaml
+++ b/tests/fake-smartsolar-mppt.yaml
@@ -12,6 +12,7 @@ esp8266:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  min_auth_mode: WPA2
 
 ota:
   platform: esphome


### PR DESCRIPTION
## Summary

- Add `min_auth_mode: WPA2` to all `wifi:` blocks in example and test YAML files

WPA and WEP are insecure. Setting `min_auth_mode: WPA2` ensures the device refuses to connect to open or weakly protected networks.

## Test plan

- [ ] Verify all example YAML files still validate successfully with ESPHome