### PR TITLE
Replace static const char with constexpr

### DIFF
--- a/components/victron/victron.cpp
+++ b/components/victron/victron.cpp
@@ -5,10 +5,10 @@
 
 namespace esphome::victron {
 
-static const char *const TAG = "victron";
+static constexpr char TAG[] = "victron";
 
-static const uint8_t OFF_REASONS_SIZE = 16;
-static const char *const OFF_REASONS[OFF_REASONS_SIZE] = {
+static constexpr uint8_t OFF_REASONS_SIZE = 16;
+static constexpr const char *OFF_REASONS[OFF_REASONS_SIZE] = {
     "No input power",                       // 0000 0000 0000 0001
     "Switched off (power switch)",          // 0000 0000 0000 0010
     "Switched off (device mode register)",  // 0000 0000 0000 0100


### PR DESCRIPTION
## Summary

- `static const char *const TAG` → `static constexpr char TAG[]`
- `static const uint8_t OFF_REASONS_SIZE` → `static constexpr uint8_t OFF_REASONS_SIZE`
- `static const char *const OFF_REASONS[]` → `static constexpr const char *OFF_REASONS[]`

`static const char *const` creates read-write pointers to read-only memory. `constexpr` is semantically stronger: it guarantees compile-time evaluation and makes the intent explicit.

## Test plan

- [ ] Verify the component compiles without warnings