### PR TITLE
Remove redundant name substitution prefix from entity names

### DIFF
--- a/bluesmart-charger-esp32-example.yaml
+++ b/bluesmart-charger-esp32-example.yaml
@@ -4,6 +4,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp32:
   board: esp32dev
@@ -51,26 +52,26 @@ sensor:
   - platform: victron
     victron_id: victron0
     battery_voltage:
-      name: "${name} output voltage"
+      name: "output voltage"
     battery_current:
-      name: "${name} current"
+      name: "current"
     error_code:
-      name: "${name} error code"
+      name: "error code"
     charging_mode_id:
-      name: "${name} mode id"
+      name: "mode id"
 
 text_sensor:
   - platform: victron
     victron_id: victron0
     device_type:
-      name: "${name} device type"
+      name: "device type"
     firmware_version_24bit:
-      name: "${name} firmware version"
+      name: "firmware version"
     serial_number:
-      name: "${name} serial number"
+      name: "serial number"
     hardware_revision:
-      name: "${name} hardware number"
+      name: "hardware number"
     error:
-      name: "${name} error"
+      name: "error"
     charging_mode:
-      name: "${name} charging mode"
+      name: "charging mode"

--- a/bluesmart-charger-esp8266-example.yaml
+++ b/bluesmart-charger-esp8266-example.yaml
@@ -4,6 +4,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini
@@ -48,26 +49,26 @@ sensor:
   - platform: victron
     victron_id: victron0
     battery_voltage:
-      name: "${name} output voltage"
+      name: "output voltage"
     battery_current:
-      name: "${name} current"
+      name: "current"
     error_code:
-      name: "${name} error code"
+      name: "error code"
     charging_mode_id:
-      name: "${name} mode id"
+      name: "mode id"
 
 text_sensor:
   - platform: victron
     victron_id: victron0
     device_type:
-      name: "${name} device type"
+      name: "device type"
     firmware_version_24bit:
-      name: "${name} firmware version"
+      name: "firmware version"
     serial_number:
-      name: "${name} serial number"
+      name: "serial number"
     hardware_revision:
-      name: "${name} hardware number"
+      name: "hardware number"
     error:
-      name: "${name} error"
+      name: "error"
     charging_mode:
-      name: "${name} charging mode"
+      name: "charging mode"

--- a/debug-esp32-example.yaml
+++ b/debug-esp32-example.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp32:
   board: wemos_d1_mini32
@@ -51,10 +52,10 @@ text_sensor:
   - platform: victron
     victron_id: victron0
     model_description:
-      name: "${name} model description"
+      name: "model description"
     firmware_version:
-      name: "${name} firmware version"
+      name: "firmware version"
     device_type:
-      name: "${name} device type"
+      name: "device type"
     serial_number:
-      name: "${name} serial number"
+      name: "serial number"

--- a/debug-esp8266-example.yaml
+++ b/debug-esp8266-example.yaml
@@ -6,6 +6,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini
@@ -51,10 +52,10 @@ text_sensor:
   - platform: victron
     victron_id: victron0
     model_description:
-      name: "${name} model description"
+      name: "model description"
     firmware_version:
-      name: "${name} firmware version"
+      name: "firmware version"
     device_type:
-      name: "${name} device type"
+      name: "device type"
     serial_number:
-      name: "${name} serial number"
+      name: "serial number"

--- a/multi-rs-esp8266-example.yaml
+++ b/multi-rs-esp8266-example.yaml
@@ -4,6 +4,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini
@@ -50,38 +51,38 @@ sensor:
   - platform: victron
     victron_id: victron0
     charging_mode_id:
-      name: "${name} charging mode id"
+      name: "charging mode id"
     error_code:
-      name: "${name} error code"
+      name: "error code"
     ac_out_current:
-      name: "${name} ac out current"
+      name: "ac out current"
       id: ac_current
     ac_out_voltage:
-      name: "${name} ac out voltage"
+      name: "ac out voltage"
       id: ac_voltage
     yield_total:
-      name: "${name} yield total"
+      name: "yield total"
     yield_today:
-      name: "${name} yield today"
+      name: "yield today"
     max_power_today:
-      name: "${name} max power today"
+      name: "max power today"
     yield_yesterday:
-      name: "${name} yield yesterday"
+      name: "yield yesterday"
     max_power_yesterday:
-      name: "${name} max power yesterday"
+      name: "max power yesterday"
     day_number:
-      name: "${name} day number"
+      name: "day number"
     battery_current:
-      name: "${name} battery current"
+      name: "battery current"
     panel_power:
-      name: "${name} panel power"
+      name: "panel power"
     battery_voltage:
-      name: "${name} battery voltage"
+      name: "battery voltage"
     panel_voltage:
-      name: "${name} panel voltage"
+      name: "panel voltage"
 
   - platform: template
-    name: "${name} ac out power"
+    name: "ac out power"
     # https://github.com/esphome/issues/issues/2793#issuecomment-988257209
     lambda: |-
        auto val = id(ac_voltage).state * id(ac_current).state;
@@ -94,14 +95,14 @@ text_sensor:
   - platform: victron
     victron_id: victron0
     device_type:
-      name: "${name} device type"
+      name: "device type"
     serial_number:
-      name: "${name} serial number"
+      name: "serial number"
     firmware_version_24bit:
-      name: "${name} firmware version 24bit"
+      name: "firmware version 24bit"
     charging_mode:
-      name: "${name} charging mode"
+      name: "charging mode"
     error:
-      name: "${name} error"
+      name: "error"
     device_mode:
-      name: "${name} device mode"
+      name: "device mode"

--- a/orion-xs-esp32-example.yaml
+++ b/orion-xs-esp32-example.yaml
@@ -4,7 +4,7 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
+  friendly_name: ${name}
 
 esp32:
   board: esp32dev
@@ -51,36 +51,36 @@ sensor:
   - platform: victron
     victron_id: victron0
     battery_voltage:
-      name: "${name} output voltage"
+      name: "output voltage"
     battery_current:
-      name: "${name} output current"
+      name: "output current"
     instantaneous_power:
-      name: "${name} output power"
+      name: "output power"
     dc_input_voltage:
-      name: "${name} input voltage"
+      name: "input voltage"
     dc_input_current:
-      name: "${name} input current"
+      name: "input current"
     dc_input_power:
-      name: "${name} input power"
+      name: "input power"
     charging_mode_id:
-      name: "${name} charging mode id"
+      name: "charging mode id"
     off_reason_bitmask:
-      name: "${name} off reason bitmask"
+      name: "off reason bitmask"
     error_code:
-      name: "${name} error code"
+      name: "error code"
 
 text_sensor:
   - platform: victron
     victron_id: victron0
     device_type:
-      name: "${name} device type"
+      name: "device type"
     firmware_version_24bit:
-      name: "${name} firmware version"
+      name: "firmware version"
     serial_number:
-      name: "${name} serial number"
+      name: "serial number"
     charging_mode:
-      name: "${name} charging mode"
+      name: "charging mode"
     off_reason:
-      name: "${name} off reason"
+      name: "off reason"
     error:
-      name: "${name} error"
+      name: "error"

--- a/orion-xs-esp8266-example.yaml
+++ b/orion-xs-esp8266-example.yaml
@@ -4,7 +4,7 @@ substitutions:
 
 esphome:
   name: ${name}
-  min_version: 2024.6.0
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini
@@ -49,36 +49,36 @@ sensor:
   - platform: victron
     victron_id: victron0
     battery_voltage:
-      name: "${name} output voltage"
+      name: "output voltage"
     battery_current:
-      name: "${name} output current"
+      name: "output current"
     instantaneous_power:
-      name: "${name} output power"
+      name: "output power"
     dc_input_voltage:
-      name: "${name} input voltage"
+      name: "input voltage"
     dc_input_current:
-      name: "${name} input current"
+      name: "input current"
     dc_input_power:
-      name: "${name} input power"
+      name: "input power"
     charging_mode_id:
-      name: "${name} charging mode id"
+      name: "charging mode id"
     off_reason_bitmask:
-      name: "${name} off reason bitmask"
+      name: "off reason bitmask"
     error_code:
-      name: "${name} error code"
+      name: "error code"
 
 text_sensor:
   - platform: victron
     victron_id: victron0
     device_type:
-      name: "${name} device type"
+      name: "device type"
     firmware_version_24bit:
-      name: "${name} firmware version"
+      name: "firmware version"
     serial_number:
-      name: "${name} serial number"
+      name: "serial number"
     charging_mode:
-      name: "${name} charging mode"
+      name: "charging mode"
     off_reason:
-      name: "${name} off reason"
+      name: "off reason"
     error:
-      name: "${name} error"
+      name: "error"

--- a/phoenix-charger-esp8266-example.yaml
+++ b/phoenix-charger-esp8266-example.yaml
@@ -4,6 +4,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini
@@ -50,40 +51,40 @@ sensor:
   - platform: victron
     victron_id: victron0
     battery_voltage:
-      name: "${name} battery voltage"
+      name: "battery voltage"
     battery_voltage_2:
-      name: "${name} battery voltage 2"
+      name: "battery voltage 2"
     battery_voltage_3:
-      name: "${name} battery voltage 3"
+      name: "battery voltage 3"
     battery_current:
-      name: "${name} battery current"
+      name: "battery current"
     battery_current_2:
-      name: "${name} battery current 2"
+      name: "battery current 2"
     battery_current_3:
-      name: "${name} battery current 3"
+      name: "battery current 3"
     error_code:
-      name: "${name} error code"
+      name: "error code"
     charging_mode_id:
-      name: "${name} charging mode id"
+      name: "charging mode id"
     device_mode_id:
-      name: "${name} device mode id"
+      name: "device mode id"
 
 text_sensor:
   - platform: victron
     victron_id: victron0
     error:
-      name: "${name} error"
+      name: "error"
     charging_mode:
-      name: "${name} charging mode"
+      name: "charging mode"
     device_type:
-      name: "${name} device type"
+      name: "device type"
     serial_number:
-      name: "${name} serial number"
+      name: "serial number"
     device_mode:
-      name: "${name} device mode"
+      name: "device mode"
 
 binary_sensor:
   - platform: victron
     victron_id: victron0
     relay_state:
-      name: "${name} relay state"
+      name: "relay state"

--- a/phoenix-inverter-esp8266-example.yaml
+++ b/phoenix-inverter-esp8266-example.yaml
@@ -4,6 +4,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini
@@ -50,47 +51,47 @@ sensor:
   - platform: victron
     victron_id: victron0
     battery_voltage:
-      name: "${name} battery voltage"
+      name: "battery voltage"
     battery_current:
-      name: "${name} battery current"
+      name: "battery current"
     charging_mode_id:
-      name: "${name} charging mode id"
+      name: "charging mode id"
     device_mode_id:
-      name: "${name} device mode id"
+      name: "device mode id"
     ac_out_voltage:
-      name: "${name} ac out voltage"
+      name: "ac out voltage"
     ac_out_current:
-      name: "${name} ac out current"
+      name: "ac out current"
     ac_out_apparent_power:
-      name: "${name} ac out apparent power"
+      name: "ac out apparent power"
     warning_code:
-      name: "${name} warning code"
+      name: "warning code"
     off_reason_bitmask:
-      name: "${name} off reason bitmask"
+      name: "off reason bitmask"
 
 text_sensor:
   - platform: victron
     victron_id: victron0
     alarm_reason:
-      name: "${name} alarm reason"
+      name: "alarm reason"
     # TODO: "OR"
     charging_mode:
-      name: "${name} charging mode"
+      name: "charging mode"
     firmware_version:
-      name: "${name} firmware version"
+      name: "firmware version"
     device_type:
-      name: "${name} device type"
+      name: "device type"
     serial_number:
-      name: "${name} serial number"
+      name: "serial number"
     device_mode:
-      name: "${name} device mode"
+      name: "device mode"
     warning:
-      name: "${name} warning"
+      name: "warning"
     off_reason:
-      name: "${name} off reason"
+      name: "off reason"
 
 binary_sensor:
   - platform: victron
     victron_id: victron0
     relay_state:
-      name: "${name} relay state"
+      name: "relay state"

--- a/smartshunt-esp8266-example.yaml
+++ b/smartshunt-esp8266-example.yaml
@@ -4,6 +4,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini
@@ -50,84 +51,84 @@ sensor:
   - platform: victron
     victron_id: victron0
     battery_voltage:
-      name: "${name} battery voltage"
+      name: "battery voltage"
     auxiliary_battery_voltage:
-      name: "${name} auxiliary battery voltage"
+      name: "auxiliary battery voltage"
     midpoint_voltage_of_the_battery_bank:
-      name: "${name} midpoint voltage of the battery bank"
+      name: "midpoint voltage of the battery bank"
     midpoint_deviation_of_the_battery_bank:
-      name: "${name} midpoint deviation of the battery bank"
+      name: "midpoint deviation of the battery bank"
     battery_current:
-      name: "${name} battery current"
+      name: "battery current"
     battery_temperature:
-      name: "${name} battery temperature"
+      name: "battery temperature"
     instantaneous_power:
-      name: "${name} instantaneous power"
+      name: "instantaneous power"
     consumed_amp_hours:
-      name: "${name} consumed amp hours"
+      name: "consumed amp hours"
     state_of_charge:
-      name: "${name} state of charge"
+      name: "state of charge"
     time_to_go:
-      name: "${name} time to go"
+      name: "time to go"
     depth_of_the_deepest_discharge:
-      name: "${name} depth of the deepest discharge"
+      name: "depth of the deepest discharge"
     depth_of_the_last_discharge:
-      name: "${name} depth of the last discharge"
+      name: "depth of the last discharge"
     depth_of_the_average_discharge:
-      name: "${name} depth of the average discharge"
+      name: "depth of the average discharge"
     number_of_charge_cycles:
-      name: "${name} number of charge cycles"
+      name: "number of charge cycles"
     number_of_full_discharges:
-      name: "${name} number of full discharges"
+      name: "number of full discharges"
     cumulative_amp_hours_drawn:
-      name: "${name} cumulative amp hours drawn"
+      name: "cumulative amp hours drawn"
     min_battery_voltage:
-      name: "${name} min battery voltage"
+      name: "min battery voltage"
     max_battery_voltage:
-      name: "${name} max battery voltage"
+      name: "max battery voltage"
     last_full_charge:
-      name: "${name} last full charge"
+      name: "last full charge"
     number_of_automatic_synchronizations:
-      name: "${name} number of automatic synchronizations"
+      name: "number of automatic synchronizations"
     number_of_low_main_voltage_alarms:
-      name: "${name} number of low main voltage alarms"
+      name: "number of low main voltage alarms"
     number_of_high_main_voltage_alarms:
-      name: "${name} number of high main voltage alarms"
+      name: "number of high main voltage alarms"
     number_of_low_auxiliary_voltage_alarms:
-      name: "${name} number of low auxiliary voltage alarms"
+      name: "number of low auxiliary voltage alarms"
     number_of_high_auxiliary_voltage_alarms:
-      name: "${name} number of high auxiliary voltage alarms"
+      name: "number of high auxiliary voltage alarms"
     min_auxiliary_battery_voltage:
-      name: "${name} min auxiliary battery voltage"
+      name: "min auxiliary battery voltage"
     max_auxiliary_battery_voltage:
-      name: "${name} max auxiliary battery voltage"
+      name: "max auxiliary battery voltage"
     amount_of_discharged_energy:
-      name: "${name} amount of discharged energy"
+      name: "amount of discharged energy"
     amount_of_charged_energy:
-      name: "${name} amount of charged energy"
+      name: "amount of charged energy"
     dc_monitor_mode_id:
-      name: "${name} dc monitor mode id"
+      name: "dc monitor mode id"
 
 text_sensor:
   - platform: victron
     victron_id: victron0
     alarm_condition_active:
-      name: "${name} alarm condition active"
+      name: "alarm condition active"
     alarm_reason:
-      name: "${name} alarm reason"
+      name: "alarm reason"
     model_description:
-      name: "${name} model description"
+      name: "model description"
     firmware_version:
-      name: "${name} firmware version"
+      name: "firmware version"
     device_type:
-      name: "${name} device type"
+      name: "device type"
     serial_number:
-      name: "${name} serial number"
+      name: "serial number"
     dc_monitor_mode:
-      name: "${name} dc monitor mode"
+      name: "dc monitor mode"
 
 binary_sensor:
   - platform: victron
     victron_id: victron0
     relay_state:
-      name: "${name} relay state"
+      name: "relay state"

--- a/smartsolar-mppt-esp8266-example-advanced.yaml
+++ b/smartsolar-mppt-esp8266-example-advanced.yaml
@@ -8,6 +8,7 @@ substitutions:
 
 esphome:
   name: "${lower_devicename}"
+  friendly_name: ${devicename}
 
 esp8266:
   board: d1_mini
@@ -25,7 +26,7 @@ wifi:
 
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
-    ssid: "${devicename} Hotspot"
+    ssid: "Hotspot"
     password: !secret wifi_password
 
 captive_portal:
@@ -130,7 +131,7 @@ sensor:
       name: "Tracker mode id"
 
   - platform: wifi_signal
-    name: "${devicename} WiFi Signal Sensor"
+    name: "WiFi Signal Sensor"
     id: rssi_sensor
     update_interval: 15s
 
@@ -153,7 +154,7 @@ sensor:
         return quality;
 
   - platform: uptime
-    name: "${devicename} Uptime"
+    name: "Uptime"
     id: uptime_s
     update_interval: 5s
 
@@ -222,26 +223,26 @@ text_sensor:
       name: "Device Type"
 
   - platform: template
-    name: "${devicename} Config Version"
+    name: "Config Version"
     icon: mdi:information-outline
     lambda: |-
       return {"${config_version}"};
   - platform: version
-    name: "${devicename} Esphome Version"
+    name: "Esphome Version"
     icon: mdi:information-outline
   - platform: wifi_info
     ip_address:
-      name: "${devicename} IP Address"
+      name: "IP Address"
       icon: mdi:ip
     ssid:
-      name: "${devicename} Connected SSID"
+      name: "Connected SSID"
       icon: mdi:wifi
     bssid:
-      name: "${devicename} Connected BSSID"
+      name: "Connected BSSID"
     mac_address:
-      name: "${devicename} Mac Wifi Address"
+      name: "Mac Wifi Address"
   - platform: template
-    name: "${devicename} Uptime (formatted)"
+    name: "Uptime (formatted)"
     lambda: |-
       uint32_t dur = id(uptime_s).state;
       int dys = 0;
@@ -268,4 +269,4 @@ text_sensor:
 switch:
   - platform: restart
     icon: mdi:reload-alert
-    name: "${devicename} Restart"
+    name: "Restart"

--- a/smartsolar-mppt-esp8266-example.yaml
+++ b/smartsolar-mppt-esp8266-example.yaml
@@ -4,6 +4,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
 
 esp8266:
   board: d1_mini
@@ -50,54 +51,54 @@ sensor:
   - platform: victron
     victron_id: victron0
     max_power_yesterday:
-      name: "${name} max power yesterday"
+      name: "max power yesterday"
     max_power_today:
-      name: "${name} max power today"
+      name: "max power today"
     yield_total:
-      name: "${name} yield total"
+      name: "yield total"
     yield_yesterday:
-      name: "${name} yield yesterday"
+      name: "yield yesterday"
     yield_today:
-      name: "${name} yield today"
+      name: "yield today"
     panel_voltage:
-      name: "${name} panel voltage"
+      name: "panel voltage"
     panel_power:
-      name: "${name} panel power"
+      name: "panel power"
     battery_current:
-      name: "${name} panel current"
+      name: "panel current"
     battery_voltage:
-      name: "${name} battery voltage"
+      name: "battery voltage"
     day_number:
-      name: "${name} day number"
+      name: "day number"
     charging_mode_id:
-      name: "${name} charging mode id"
+      name: "charging mode id"
     error_code:
-      name: "${name} error code"
+      name: "error code"
     tracking_mode_id:
-      name: "${name} tracking mode id"
+      name: "tracking mode id"
     load_current:
-      name: "${name} load current"
+      name: "load current"
 
 text_sensor:
   - platform: victron
     victron_id: victron0
     charging_mode:
-      name: "${name} charging mode"
+      name: "charging mode"
     error:
-      name: "${name} error"
+      name: "error"
     tracking_mode:
-      name: "${name} tracking mode"
+      name: "tracking mode"
     firmware_version:
-      name: "${name} firmware version"
+      name: "firmware version"
     device_type:
-      name: "${name} device type"
+      name: "device type"
     serial_number:
-      name: "${name} serial number"
+      name: "serial number"
 
 binary_sensor:
   - platform: victron
     victron_id: victron0
     load_state:
-      name: "${name} load state"
+      name: "load state"
     relay_state:
-      name: "${name} relay state"
+      name: "relay state"


### PR DESCRIPTION
## Summary

- Add `friendly_name: ${name}` (or `${devicename}` for the advanced example) to the `esphome:` block in all example configs
- Remove the `"${name} ` prefix from all entity names

ESPHome's `friendly_name` feature (introduced in 2023.4) prepends the device name to all entity names automatically. Keeping the manual `${name}` prefix in entity names results in a doubled prefix in Home Assistant (e.g. "Victron MPPT Victron MPPT battery voltage"). Removing it keeps the YAML readable and avoids the duplication.

## Test plan

- [ ] Verify all example YAML files still validate successfully
- [ ] Verify entity names appear correctly in Home Assistant (device name + entity name, no duplication)