### PR TITLE
Replace deprecated ESPHome APIs

### DIFF
--- a/components/victron/binary_sensor.py
+++ b/components/victron/binary_sensor.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, ICON_EMPTY
 
 from . import CONF_VICTRON_ID, VICTRON_COMPONENT_SCHEMA
 
@@ -19,14 +18,8 @@ BINARY_SENSORS = [
 
 CONFIG_SCHEMA = VICTRON_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_LOAD_STATE): binary_sensor.binary_sensor_schema(
-            binary_sensor.BinarySensor,
-            icon=ICON_EMPTY,
-        ),
-        cv.Optional(CONF_RELAY_STATE): binary_sensor.binary_sensor_schema(
-            binary_sensor.BinarySensor,
-            icon=ICON_EMPTY,
-        ),
+        cv.Optional(CONF_LOAD_STATE): binary_sensor.binary_sensor_schema(),
+        cv.Optional(CONF_RELAY_STATE): binary_sensor.binary_sensor_schema(),
     }
 )
 
@@ -36,6 +29,5 @@ def to_code(config):
     for key in BINARY_SENSORS:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[CONF_ID])
-            yield binary_sensor.register_binary_sensor(sens, conf)
+            sens = yield binary_sensor.new_binary_sensor(conf)
             cg.add(getattr(hub, f"set_{key}_binary_sensor")(sens))

--- a/components/victron/text_sensor.py
+++ b/components/victron/text_sensor.py
@@ -1,7 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
 
 from . import CONF_VICTRON_ID, VICTRON_COMPONENT_SCHEMA
 
@@ -47,49 +46,21 @@ TEXT_SENSORS = [
 
 CONFIG_SCHEMA = VICTRON_COMPONENT_SCHEMA.extend(
     {
-        cv.Optional(CONF_CHARGING_MODE): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor
-        ),
-        cv.Optional(CONF_ERROR): text_sensor.text_sensor_schema(text_sensor.TextSensor),
-        cv.Optional(CONF_WARNING): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor
-        ),
-        cv.Optional(CONF_TRACKING_MODE): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor
-        ),
-        cv.Optional(CONF_DEVICE_MODE): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor
-        ),
-        cv.Optional(CONF_FIRMWARE_VERSION): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor
-        ),
-        cv.Optional(CONF_FIRMWARE_VERSION_24BIT): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor
-        ),
-        cv.Optional(CONF_DEVICE_TYPE): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor
-        ),
-        cv.Optional(CONF_SERIAL_NUMBER): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor
-        ),
-        cv.Optional(CONF_HARDWARE_REVISION): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor
-        ),
-        cv.Optional(CONF_ALARM_CONDITION_ACTIVE): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor
-        ),
-        cv.Optional(CONF_ALARM_REASON): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor
-        ),
-        cv.Optional(CONF_MODEL_DESCRIPTION): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor
-        ),
-        cv.Optional(CONF_DC_MONITOR_MODE): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor
-        ),
-        cv.Optional(CONF_OFF_REASON): text_sensor.text_sensor_schema(
-            text_sensor.TextSensor
-        ),
+        cv.Optional(CONF_CHARGING_MODE): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_ERROR): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_WARNING): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_TRACKING_MODE): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_DEVICE_MODE): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_FIRMWARE_VERSION): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_FIRMWARE_VERSION_24BIT): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_DEVICE_TYPE): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_SERIAL_NUMBER): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_HARDWARE_REVISION): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_ALARM_CONDITION_ACTIVE): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_ALARM_REASON): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_MODEL_DESCRIPTION): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_DC_MONITOR_MODE): text_sensor.text_sensor_schema(),
+        cv.Optional(CONF_OFF_REASON): text_sensor.text_sensor_schema(),
     }
 )
 
@@ -99,6 +70,5 @@ def to_code(config):
     for key in TEXT_SENSORS:
         if key in config:
             conf = config[key]
-            sens = cg.new_Pvariable(conf[CONF_ID])
-            yield text_sensor.register_text_sensor(sens, conf)
+            sens = yield text_sensor.new_text_sensor(conf)
             cg.add(getattr(hub, f"set_{key}_text_sensor")(sens))


### PR DESCRIPTION
## Summary

- **`text_sensor.py`**: Remove positional `TextSensor` arg from all `text_sensor_schema()` calls; replace `register_text_sensor` + `new_Pvariable` with `new_text_sensor`; remove unused `CONF_ID` import
- **`binary_sensor.py`**: Remove positional `BinarySensor` arg and `icon=ICON_EMPTY` from all `binary_sensor_schema()` calls; replace `register_binary_sensor` + `new_Pvariable` with `new_binary_sensor`; remove unused `CONF_ID` and `ICON_EMPTY` imports

These constants and positional arguments were deprecated and produce warnings during `esphome compile`.

## Test plan

- [ ] Verify no deprecation warnings appear: `esphome config smartsolar-mppt-esp8266-example.yaml 2>&1 | grep -i deprecat`
- [ ] Verify all example configurations still validate and compile